### PR TITLE
Align intra-workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,9 +3894,9 @@ dependencies = [
  "memchr",
  "nom",
  "open",
- "plow_linter 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_ontology 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_package_management 0.3.2",
+ "plow_linter 0.2.9",
+ "plow_ontology 0.2.2",
+ "plow_package_management 0.3.4",
  "rayon",
  "regex",
  "reqwest",
@@ -3924,18 +3924,6 @@ dependencies = [
 [[package]]
 name = "plow_graphify"
 version = "0.2.3"
-dependencies = [
- "field33_rdftk_core_temporary_fork",
- "field33_rdftk_iri_temporary_fork",
- "harriet 0.3.0",
- "thiserror",
-]
-
-[[package]]
-name = "plow_graphify"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbb861b0f23c6c19014d9586c1d9b1f3f261edd5edca0edf53491f8f8bb7255"
 dependencies = [
  "field33_rdftk_core_temporary_fork",
  "field33_rdftk_iri_temporary_fork",
@@ -4006,40 +3994,9 @@ dependencies = [
  "field33_rdftk_iri_temporary_fork",
  "harriet 0.3.0",
  "nom",
- "plow_graphify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_ontology 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_package_management 0.3.2",
- "rayon",
- "regex",
- "rustrict 0.5.14",
- "semver 1.0.17",
- "serde",
- "serde_json",
- "spdx 0.9.0",
- "tempdir",
- "thiserror",
- "uuid 1.3.0",
-]
-
-[[package]]
-name = "plow_linter"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3185aee2045778613160a7d07d1fdb8abcb55f2b6e48dbbea6ac0d094a54bed4"
-dependencies = [
- "addr",
- "anyhow",
- "aquamarine",
- "chashmap",
- "darc",
- "email_address",
- "field33_rdftk_core_temporary_fork",
- "field33_rdftk_iri_temporary_fork",
- "harriet 0.3.0",
- "nom",
- "plow_graphify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_ontology 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_package_management 0.3.2",
+ "plow_graphify 0.2.3",
+ "plow_ontology 0.2.2",
+ "plow_package_management 0.3.4",
  "rayon",
  "regex",
  "rustrict 0.5.14",
@@ -4074,22 +4031,8 @@ dependencies = [
  "anyhow",
  "field33_rdftk_core_temporary_fork",
  "field33_rdftk_iri_temporary_fork",
- "plow_graphify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_linter 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "plow_ontology"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8d7a0678d0c3e0bab3683ea1202b47d30b6aa532b76d0c94176eb0db45873e"
-dependencies = [
- "anyhow",
- "field33_rdftk_core_temporary_fork",
- "field33_rdftk_iri_temporary_fork",
- "plow_graphify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plow_graphify 0.2.3",
+ "plow_linter 0.2.9",
  "serde",
  "serde_json",
 ]
@@ -4122,33 +4065,6 @@ dependencies = [
 
 [[package]]
 name = "plow_package_management"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718f13d2078c5240eb1b3ad5358453835686e2b467952f302e7131ec200b4b80"
-dependencies = [
- "anyhow",
- "camino",
- "dirs",
- "fallible-iterator",
- "field33_rdftk_core_temporary_fork",
- "field33_rdftk_iri_temporary_fork",
- "git2",
- "glob",
- "harriet 0.3.0",
- "itertools 0.10.5",
- "plow_graphify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "plow_ontology 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pubgrub",
- "semver 1.0.17",
- "serde",
- "serde_json",
- "sha2 0.10.6",
- "thiserror",
- "toml",
-]
-
-[[package]]
-name = "plow_package_management"
 version = "0.3.4"
 dependencies = [
  "anyhow",
@@ -4161,9 +4077,9 @@ dependencies = [
  "glob",
  "harriet 0.3.0",
  "itertools 0.10.5",
- "plow_graphify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plow_graphify 0.2.3",
  "plow_linter 0.2.9",
- "plow_ontology 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plow_ontology 0.2.2",
  "pubgrub",
  "semver 1.0.17",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,9 @@ members = [
 
   "plow_backend_reference"
 ]
+
+[workspace.dependencies]
+plow_graphify = { version = "0.2.3", path = "./plow_graphify" }
+plow_linter = { version = "0.2.9", path = "./plow_linter" }
+plow_ontology = { version = "0.2.2", path = "./plow_ontology" }
+plow_package_management = { version = "0.3.4", path = "./plow_package_management" }

--- a/plow_cli/Cargo.toml
+++ b/plow_cli/Cargo.toml
@@ -14,6 +14,10 @@ name = "plow"
 path = "src/main.rs"
 
 [dependencies]
+plow_package_management = { workspace = true }
+plow_linter = { workspace = true }
+plow_ontology = { workspace = true }
+
 dialoguer = "0.10"
 clap = "3"
 nom = "7"
@@ -26,9 +30,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.11", features = ["blocking", "multipart", "json"]}
 colored = "2"
-plow_package_management = "0.3"
-plow_linter = "0.2"
-plow_ontology = "0.2"
 thiserror = "1"
 fallible-iterator = "0.2"
 sha2 = "0.10"

--- a/plow_gui/Cargo.toml
+++ b/plow_gui/Cargo.toml
@@ -9,9 +9,11 @@ repository = "https://github.com/field33/plow/"
 edition = "2021"
 
 [dependencies]
+# NOTE: plow_gui is out of sync with the rest of the crates and currently in maintenance status
 plow_ontology = "0.1"
 plow_package_management = "0.1"
 plow_linter = "0.1"
+
 harriet = "0.1"
 nom = "7"
 anyhow = { version = "1.0.42", features = ["backtrace"] }

--- a/plow_linter/Cargo.toml
+++ b/plow_linter/Cargo.toml
@@ -8,9 +8,10 @@ repository = "https://github.com/field33/plow/"
 edition = "2021"
 
 [dependencies]
-plow_ontology = "0.2"
-plow_graphify = "0.2"
-plow_package_management =  "0.3"
+plow_ontology = { workspace = true }
+plow_graphify = { workspace = true }
+plow_package_management = { workspace = true }
+
 anyhow = { version = "1.0.53", features = ["backtrace"] }
 thiserror = "1"
 harriet = "0.3"

--- a/plow_ontology/Cargo.toml
+++ b/plow_ontology/Cargo.toml
@@ -12,7 +12,8 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-plow_graphify = "0.2"
+plow_graphify = { workspace = true }
+
 anyhow = { version = "1", features = ["backtrace"] }
 field33_rdftk_core_temporary_fork = "0.3"
 field33_rdftk_iri_temporary_fork = "0.1"
@@ -20,5 +21,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-plow_linter = "0.2"
+plow_linter = { workspace = true }
 

--- a/plow_package_management/Cargo.toml
+++ b/plow_package_management/Cargo.toml
@@ -9,8 +9,9 @@ repository = "https://github.com/field33/plow/"
 edition = "2021"
 
 [dependencies]
-plow_ontology = "0.2"
-plow_graphify = "0.2"
+plow_ontology = { workspace = true }
+plow_graphify = { workspace = true }
+
 anyhow = { version = "1", features = ["backtrace"] }
 thiserror = "1"
 harriet = "0.3"
@@ -30,9 +31,10 @@ toml = "0.5"
 camino = "1"
 
 [dev-dependencies]
+plow_linter = { workspace = true }
+plow_ontology = { workspace = true }
+
 tempdir = "0.3"
-plow_linter = { path = "../plow_linter" }
-plow_ontology = "0.2"
 pubgrub = "0.2"
 semver = "1"
 


### PR DESCRIPTION
This sets up the dependencies between the crates in the workspace, so that they depend on the correct other version of the crates in the workspace (we had problems in the past to keep them in sync).

This is done via two mechanisms:
- Specifying [multiple locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations) for the dependency. This allows us to use the local `path` version when developing locally, without needing any tweaks. We also provide a `version`, which should be the version of the crate as present in the repository. This one will be used when the package is being published.
- Centralizing the dependencies in the workspace root, and then using them in the individual crates via the `some_crate = { workspace = true }` workspace inheritance.

In combination, with this, when we bump the version of an individual crate, we only have to bump it in the crate itself, and in the root Cargo.toml.