### PR TITLE
Configure cargo-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,18 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
+
+  release:
+    needs: [test]
+    if: ${{ github.ref == 'refs/heads/main' }}
+    name: Release crate versions (if required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-release
+      - name: Publish new crate version
+        run: cargo release publish --execute

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ plow_graphify = { version = "0.2.3", path = "./plow_graphify" }
 plow_linter = { version = "0.2.9", path = "./plow_linter" }
 plow_ontology = { version = "0.2.2", path = "./plow_ontology" }
 plow_package_management = { version = "0.3.4", path = "./plow_package_management" }
+
+[workspace.metadata.release]
+push = false

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,8 @@
+# Publishing a new version
+
+- Create a new branch
+- Bump the version of the crate(s) you want to release (via [cargo-release](https://github.com/crate-ci/cargo-release))(:
+  - Dry run with e.g. `cargo release version --package plow_graphify patch`
+  - Actually execute it by appending the `--execute` flag
+- Push the branch
+- Merge the branch to `main` (the release workflow there should take care of publishing the crate)

--- a/plow_backend_reference/Cargo.toml
+++ b/plow_backend_reference/Cargo.toml
@@ -53,5 +53,5 @@ url = "2"
 fs_extra = "1"
 dotenv = "0.15"
 
-
-
+[package.metadata.release]
+publish = false


### PR DESCRIPTION
Blocked on setting up a `test` Github Action step (so we can have some assurance of correctness before running a `release` step).