### PR TITLE
Switch to vendored deps for libgit2 and libopenssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.26.0+1.1.1u"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1098,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/plow_cli/Cargo.toml
+++ b/plow_cli/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1"
 fallible-iterator = "0.2"
 sha2 = "0.10"
 rayon = "1"
-git2 = "0.14" 
+git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
 chrono = "0.4"
 memchr = "2"
 lazy_static = "1"


### PR DESCRIPTION
This should make it easier to cross-compile for M1 macs in CI