### PR TITLE
Set up first integration test for plow_cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +62,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -125,6 +146,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -317,6 +349,12 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -648,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "harriet"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a5be22faafbde9e1b96cd39eddc8f98eb015fa8b7cb35de24bf7ee20d7c1c9"
+checksum = "d454333c41704fd53c868589a401cf56294591b9d76d4f8b7428bd7a402689ee"
 dependencies = [
  "anyhow",
  "cookie-factory",
@@ -1200,6 +1238,7 @@ name = "plow_cli"
 version = "0.5.2"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "base64",
  "camino",
  "chrono",
@@ -1305,6 +1344,34 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools 0.10.5",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1503,6 +1570,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 
 [[package]]
 name = "regex-syntax"
@@ -1799,6 +1872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,6 +2116,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/plow_cli/Cargo.toml
+++ b/plow_cli/Cargo.toml
@@ -21,7 +21,7 @@ plow_ontology = { workspace = true }
 dialoguer = "0.10"
 clap = "3"
 nom = "7"
-harriet = "0.3"
+harriet = "0.3.1"
 anyhow = { version = "1", features = ["backtrace"] }
 dirs = "4"
 camino = "1"
@@ -45,3 +45,6 @@ fs_extra = "1"
 which = "4"
 open = "3"
 base64 = "0.13"
+
+[dev-dependencies]
+assert_cmd = "2.0.12"

--- a/plow_cli/src/manifest.rs
+++ b/plow_cli/src/manifest.rs
@@ -551,7 +551,7 @@ impl<'manifest> FieldManifest<'manifest> {
     pub fn create_owl_imports_and_serialize(
         &self,
         new_predicate: (
-            Whitespace<'manifest>,
+            Option<Whitespace<'manifest>>,
             harriet::Verb<'manifest>,
             ObjectList<'manifest>,
             Option<Whitespace<'manifest>>,

--- a/plow_cli/src/subcommand/init/field.rs
+++ b/plow_cli/src/subcommand/init/field.rs
@@ -131,9 +131,9 @@ pub fn new(name: &str) -> std::string::String {
         PredicateObjectList {
             list: vec![
                 (
-                    Whitespace {
+                    Some(Whitespace {
                         whitespace: " ".into(),
-                    },
+                    }),
                     harriet::Verb::IRI(IRI::PrefixedName(PrefixedName {
                         prefix: Some(Cow::Borrowed("rdf")),
                         name: Some(Cow::Borrowed("type")),
@@ -264,20 +264,20 @@ pub fn make_predicate_stringy_object<'list>(
     comment_out_with_explanation: Option<&'list str>,
     language_tag: Option<&'list str>,
 ) -> (
-    Whitespace<'list>,
+    Option<Whitespace<'list>>,
     harriet::Verb<'list>,
     ObjectList<'list>,
     Option<Whitespace<'list>>,
 ) {
     (
-        comment_out_with_explanation.map_or_else(
+        Some(comment_out_with_explanation.map_or_else(
             || Whitespace {
                 whitespace: "\n".into(),
             },
             |comment_out_with_explanation| Whitespace {
                 whitespace: comment_out_with_explanation.into(),
             },
-        ),
+        )),
         harriet::Verb::IRI(IRI::PrefixedName(PrefixedName {
             prefix: Some(Cow::Borrowed(predicate_prefix)),
             name: Some(Cow::Borrowed(predicate_name)),
@@ -308,15 +308,15 @@ pub fn make_predicate_object<'list>(
     predicate_name: &'list str,
     object_list: ObjectList<'list>,
 ) -> (
-    Whitespace<'list>,
+    Option<Whitespace<'list>>,
     harriet::Verb<'list>,
     ObjectList<'list>,
     Option<Whitespace<'list>>,
 ) {
     (
-        Whitespace {
+        Some(Whitespace {
             whitespace: "\n".into(),
-        },
+        }),
         harriet::Verb::IRI(IRI::PrefixedName(PrefixedName {
             prefix: Some(Cow::Borrowed(predicate_prefix)),
             name: Some(Cow::Borrowed(predicate_name)),

--- a/plow_cli/tests/tests.rs
+++ b/plow_cli/tests/tests.rs
@@ -1,0 +1,14 @@
+use std::os::unix::prelude::CommandExt;
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+
+/// If just executing the `plow` command without any arguments, we should exit with code `0`.
+#[test]
+fn no_arguments_correct_exit_code() {
+    let out = Command::cargo_bin("plow")
+        .unwrap()
+        .assert();
+
+    out.code(0);
+}

--- a/plow_package_management/Cargo.toml
+++ b/plow_package_management/Cargo.toml
@@ -14,7 +14,7 @@ plow_graphify = { workspace = true }
 
 anyhow = { version = "1", features = ["backtrace"] }
 thiserror = "1"
-harriet = "0.3"
+harriet = "0.3.1"
 field33_rdftk_core_temporary_fork = "0.3"
 field33_rdftk_iri_temporary_fork = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/plow_package_management/src/edit.rs
+++ b/plow_package_management/src/edit.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use harriet::{
     IRIReference, Literal, Object, ObjectList, PredicateObjectList, PrefixedName, RDFLiteral,
     Statement, StringLiteralQuote, Subject, Triples, TurtleDocument, TurtleString, Verb,
-    Whitespace, IRI,
+    IRI,
 };
 use plow_ontology::constants::REGISTRY_DEPENDENCY;
 use std::borrow::Cow;
@@ -31,9 +31,7 @@ impl EditOperation for AddDependency {
             PredicateObjectList {
                 list: vec![
                     (
-                        Whitespace {
-                            whitespace: "".into(),
-                        },
+                        None,
                         harriet::Verb::IRI(IRI::IRIReference(IRIReference {
                             iri: Cow::Borrowed(REGISTRY_DEPENDENCY),
                         })),
@@ -53,9 +51,7 @@ impl EditOperation for AddDependency {
                         None,
                     ),
                     (
-                        Whitespace {
-                            whitespace: "".into(),
-                        },
+                        None,
                         harriet::Verb::IRI(IRI::PrefixedName(PrefixedName {
                             prefix: Some(Cow::Borrowed("owl")),
                             name: Some(Cow::Borrowed("imports")),


### PR DESCRIPTION
- Set up first integration test for `plow_cli`
- Bump some harriet version dependencies to their actual dependency version of `0.3.1` and fix some corresponding issues