### PR TITLE
Add binary install one-liner to README

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -4,5 +4,7 @@
 - Bump the version of the crate(s) you want to release (via [cargo-release](https://github.com/crate-ci/cargo-release))(:
   - Dry run with e.g. `cargo release version --package plow_graphify patch`
   - Actually execute it by appending the `--execute` flag
+- Apply rewritings (to e.g. README) via:
+  - `cargo release replace --execute`
 - Push the branch
 - Merge the branch to `main` (the release workflow there should take care of publishing the crate)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Plow is package management solution for OWL ontologies, with support for specify
 
 The CLI supports basic commands related to consuming and producing ontologies. It is suitable for both manual and automated workflows (e.g. [metadata linting in CI](https://github.com/field33/ontologies/blob/12ede2b557fde94f6a768e8b65c84929a58c05ce/.github/workflows/lint.yml#L33))
 
-To install, run:
+To install our prebuilt binaries (available for Linux and macOS), run:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/field33/plow/releases/download/plow_cli-v0.5.2/plow_cli-installer.sh | sh
+```
+
+You can also install from source via:
 
 ```sh
 cargo install plow_cli

--- a/plow_cli/Cargo.toml
+++ b/plow_cli/Cargo.toml
@@ -51,3 +51,8 @@ assert_cmd = "2.0.12"
 assert_fs = "1.0.13"
 # Works best with cargo-insta command
 insta = { version = "1.31.0", features = ["yaml"] }
+
+[package.metadata.release]
+pre-release-replacements = [
+    {file="../README.md", search="plow_cli-v.*/plow_cli-installer\\.sh \\| sh", replace="plow_cli-v{{version}}/plow_cli-installer.sh | sh"},
+]


### PR DESCRIPTION
- Add binary install one-liner to README
- Adjust `cargo release` and release instruction so that we always point to the latest installable version